### PR TITLE
Change `tar c` to `tar cf -`

### DIFF
--- a/release
+++ b/release
@@ -422,11 +422,11 @@ for EXT in $ARCHIVE_FORMATS ; do
     notice "Creating $ARCHIVENAME ..."
     case $EXT in
     .tar.gz)
-        tar c $BASENAME | gzip -9c > $ARCHIVENAME
+        tar cf - $BASENAME | gzip -9c > $ARCHIVENAME
         MIMETYPE="application/x-gzip"
         ;;
     .tar.bz2)
-        tar c $BASENAME | bzip2 -9c > $ARCHIVENAME
+        tar cf - $BASENAME | bzip2 -9c > $ARCHIVENAME
         MIMETYPE="application/x-bzip2"
         ;;
     .zip)


### PR DESCRIPTION
This fixes releasetools on DragonFly BSD, and potentially other operating systems that use a non-gnu tar.

Alternatively you could use the command `gtar` on these systems and require me to install GNU tar. 